### PR TITLE
This fixes where {a{a,b}} does not parse correctly.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -45,6 +45,10 @@ func (r *rangeQuery) addFuncArg() {
 }
 
 func (r *rangeQuery) addBraces() {
+	if len(r.nodeStack) < 2 {
+		return
+	}
+
 	right := r.popNode()
 	node := r.popNode()
 


### PR DESCRIPTION
The parser hits addBraces with only 1 element in nodeStack, skipping
work when it gets here seems to fix the issue.  I wish I could explain
better why though.

This passes all the proposed braces checks in https://github.com/xaviershay/range-spec/pull/11

All other range-spec tests pass too.